### PR TITLE
Allow retrieving longer descriptions from P4, case 1194728

### DIFF
--- a/P4Plugin/Source/P4ChangesCommand.cpp
+++ b/P4Plugin/Source/P4ChangesCommand.cpp
@@ -14,7 +14,7 @@ public:
 	{				
 		ClearStatus();
 		Conn().Log().Info() << args[0] << "::Run()" << Endl;
-		const std::string cmd = std::string("changes -s pending -u ") + Quote(task.GetP4User()) + " -c " + Quote(task.GetP4Client());
+		const std::string cmd = std::string("changes -l -s pending -u ") + Quote(task.GetP4User()) + " -c " + Quote(task.GetP4Client());
 
 		Conn().BeginList();
 		


### PR DESCRIPTION
### Purpose of this PR
Fixes the following issue: https://issuetracker.unity3d.com/issues/vcs-the-changeset-description-only-displays-up-to-30-characters-in-the-version-control-and-submit-windows

This fix appended a command-line argument to the _changes_ command so that changeset descriptions longer than 30 characters would be returned correctly in their full length.


---
### Testing status

**Manual Tests**: What did you do?
- [*] Verified that plugins work in the Editor
- [*] Ran local tests on your machine

**Automated Tests**: What did you setup? 
Automatic Yamato run
