### PR TITLE
Add plugin side GUI for SSL fingerprint confirmation

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -5,7 +5,6 @@ CXX = g++
 AR = ar
 
 GTK3_INCLUDE = -I/usr/include/gtk-3.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/pango-1.0 -I/usr/include/cairo -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/atk-1.0
-GTK3_LIBRARIES = `pkg-config --libs gtk+-3.0`
 GTK3_LIBRARIES = -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -latk-1.0 -lcairo-gobject -lcairo -lgdk_pixbuf-2.0 -lgio-2.0 -lgobject-2.0 -lglib-2.0
 
 CXXFLAGS += -O2 -g -fpermissive -Wno-deprecated-declarations $(GTK3_INCLUDE) $(P4PLUGIN_INCLUDE)

--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -4,9 +4,13 @@ CC = gcc
 CXX = g++
 AR = ar
 
-CXXFLAGS += -O2 -g -fpermissive -Wno-deprecated-declarations `pkg-config --cflags gtk+-3.0` $(P4PLUGIN_INCLUDE)
+GTK3_INCLUDE = -I/usr/include/gtk-3.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/pango-1.0 -I/usr/include/cairo -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/atk-1.0
+GTK3_LIBRARIES = `pkg-config --libs gtk+-3.0`
+GTK3_LIBRARIES = -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -latk-1.0 -lcairo-gobject -lcairo -lgdk_pixbuf-2.0 -lgio-2.0 -lgobject-2.0 -lglib-2.0
+
+CXXFLAGS += -O2 -g -fpermissive -Wno-deprecated-declarations $(GTK3_INCLUDE) $(P4PLUGIN_INCLUDE)
 LDFLAGS += -g
-LIBRARIES = -lstdc++ -lrt `pkg-config --libs gtk+-3.0`
+LIBRARIES = -lstdc++ -lrt $(GTK3_LIBRARIES)
 
 COMMON_MODULES = $(COMMON_SRCS:.c=.o)
 COMMON_MODULES := $(COMMON_MODULES:.cpp=.o)

--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -4,9 +4,9 @@ CC = gcc
 CXX = g++
 AR = ar
 
-CXXFLAGS += -O2 -g -fpermissive $(P4PLUGIN_INCLUDE)
+CXXFLAGS += -O2 -g -fpermissive -Wno-deprecated-declarations `pkg-config --cflags gtk+-3.0` $(P4PLUGIN_INCLUDE)
 LDFLAGS += -g
-LIBRARIES = -lstdc++ -lrt
+LIBRARIES = -lstdc++ -lrt `pkg-config --libs gtk+-3.0`
 
 COMMON_MODULES = $(COMMON_SRCS:.c=.o)
 COMMON_MODULES := $(COMMON_MODULES:.cpp=.o)
@@ -18,7 +18,7 @@ TESTSERVER_TARGET= Build/$(PLATFORM)/TestServer
 P4PLUGIN_MODULES = $(P4PLUGIN_SRCS:.c=.o)
 P4PLUGIN_MODULES := $(P4PLUGIN_MODULES:.cpp=.o)
 P4PLUGIN_TARGET = PerforcePlugin
-P4PLUGIN_LINK += $(LIBRARIES) -ldl
+P4PLUGIN_LINK += $(LIBRARIES) -ldl -fPIC -no-pie
 
 default: all
 

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -19,6 +19,10 @@ P4PLUGIN_MODULES = $(P4PLUGIN_SRCS:.c=.o)
 P4PLUGIN_MODULES := $(P4PLUGIN_MODULES:.cpp=.o)
 P4PLUGIN_TARGET = PerforcePlugin
 
+OSX_SRCS = ./P4Plugin/Source/P4OSX.mm
+OSX_MODULES = $(OSX_SRCS:.mm=.o)
+P4PLUGIN_MODULES += $(OSX_MODULES)
+
 PLASTICSCMPLUGIN_TARGET = PlasticSCMPlugin/PlasticSCMPlugin
 
 default: all
@@ -44,6 +48,9 @@ Test/Source/%.o : Test/Source/%.cpp $(TESTSERVER_INCLS)
 
 P4Plugin/Source/%.o : P4Plugin/Source/%.cpp $(COMMON_INCLS) $(P4PLUGIN_INCLS)
 	$(CXX) $(CXXFLAGS) $(P4PLUGIN_INCLUDE) -c $< -o $@
+
+P4Plugin/Source/%.o : P4Plugin/Source/%.mm $(COMMON_INCLS) $(P4PLUGIN_INCLS)
+	$(CXX) $(CXXFLAGS) $(P4PLUGIN_INCLUDE) -c $< -o $@ 
 
 $(TESTSERVER_TARGET): $(COMMON_MODULES) $(TESTSERVER_MODULES)
 	$(CXX) -g $(LDFLAGS) -o $@ $^

--- a/P4Plugin/Source/P4ConfigCommand.cpp
+++ b/P4Plugin/Source/P4ConfigCommand.cpp
@@ -242,7 +242,8 @@ public:
 		}
 		else 
 		{
-			Conn().WarnLine(ToString("Unknown config field set on version control plugin: ", key), MAConfig);
+			if(key != "vcPerforceHost")
+				Conn().WarnLine(ToString("Unknown config field set on version control plugin: ", key), MAConfig);
 		}
 		Conn().EndResponse();
 		return true;

--- a/P4Plugin/Source/P4LoginCommand.cpp
+++ b/P4Plugin/Source/P4LoginCommand.cpp
@@ -20,9 +20,9 @@ public:
 		m_LoggedIn = false;
 		m_Password = task.GetP4Password();
 		m_CheckingForLoggedIn = args.size() > 1 && (args[1] == "-s");
-		m_TrustFingerprint = args.size() > 1 && (args[1] == "trust");
+		bool trustFingerprint = args.size() > 1 && (args[1] == "trust");
 
-		if (m_TrustFingerprint)
+		if (trustFingerprint)
 			task.CommandRun("trust -y ", this);
 
 		const std::string cmd = std::string("login") + (m_CheckingForLoggedIn ? std::string(" ") + args[1] : std::string());
@@ -119,7 +119,5 @@ private:
 	bool m_LoggedIn;
 	std::string m_Password;
 	bool m_CheckingForLoggedIn;
-	bool m_TrustFingerprint;
-	bool m_ServerFingerprint;
 
 } cLogin("login");

--- a/P4Plugin/Source/P4OSX.mm
+++ b/P4Plugin/Source/P4OSX.mm
@@ -1,0 +1,19 @@
+#include "P4Task.h"
+#import <Foundation/Foundation.h>
+#import <cocoa/cocoa.h>
+
+bool P4Task::ExecuteTrustThisServerFingerprintDialogBox(const std::string& statusMessage)
+{
+    const char* c_string = statusMessage.c_str();
+    NSString *string = [NSString stringWithUTF8String:c_string]; 
+    NSLog(@"String:%@",string);
+
+    NSAlert *alert = [[NSAlert alloc] init];
+    [alert setMessageText:string];
+    [alert setInformativeText:@"Informative text."];
+    [alert addButtonWithTitle:@"Cancel"];
+    [alert addButtonWithTitle:@"Ok"];
+    [alert runModal];
+
+    return false;
+}

--- a/P4Plugin/Source/P4OSX.mm
+++ b/P4Plugin/Source/P4OSX.mm
@@ -12,7 +12,7 @@ bool P4Task::ShowOKCancelDialogBox(const std::string& windowTitle, const std::st
             (__bridge CFStringRef)nsWindowTitle,
             (__bridge CFStringRef)nsMessage,
             CFSTR("Cancel"),
-            CFSTR("Ok"),
+            CFSTR("OK"),
             NULL,
             &cfRes);
 

--- a/P4Plugin/Source/P4OSX.mm
+++ b/P4Plugin/Source/P4OSX.mm
@@ -1,9 +1,9 @@
 #include "P4Task.h"
 #import <AppKit/AppKit.h>
 
-bool P4Task::ExecuteTrustThisServerFingerprintDialogBox(const std::string& message)
+bool P4Task::ShowOKCancelDialogBox(const std::string& windowTitle, const std::string& message)
 {
-    NSString *nsWindowTitle = @"Test Window Title";
+    NSString *nsWindowTitle = [NSString stringWithUTF8String:windowTitle.c_str()];
     NSString *nsMessage = [NSString stringWithUTF8String:message.c_str()];
 
     CFOptionFlags cfRes;

--- a/P4Plugin/Source/P4Plugin_Posix.cpp
+++ b/P4Plugin/Source/P4Plugin_Posix.cpp
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <string>
 
+
 // Program Entry point and set-up for OSX
 int main(int argc, char **argv)
 {

--- a/P4Plugin/Source/P4SpecCommand.cpp
+++ b/P4Plugin/Source/P4SpecCommand.cpp
@@ -16,6 +16,12 @@ public:
 		if (!task.CommandRun(cmd, this))
 		{
 			std::string errorMessage = GetStatusMessage();			
+			//This error is handled here instead of in P4LoginCommand as it only shows up when running the first non-login command (currently always spec)
+			if (StatusContains(GetStatus(), "login2"))
+			{
+				ClearStatus();
+				GetStatus().insert(VCSStatusItem(VCSSEV_Error, "Your chosen Perforce server has multi-factor authentication enabled. To log in please use a visual client such as p4v or the \"p4 login\" or \"p4 login2\" CLI commands"));
+			}
 			Conn().Log().Fatal() << errorMessage << Endl;
 			return false;
 		}

--- a/P4Plugin/Source/P4Task.cpp
+++ b/P4Plugin/Source/P4Task.cpp
@@ -723,18 +723,14 @@ void P4Task::EnableUTF8Mode()
 
 bool P4Task::ShowOKCancelDialogBox(const std::string& windowTitle, const std::string& message)
 {
-	int msgBoxRet = MessageBoxW(
+	int msgBoxRet = MessageBoxA(
 		NULL,
-		(LPCWSTR)std::wstring(message.begin(), message.end()).c_str(),
-		(LPCWSTR)std::wstring(windowTitle.begin(), windowTitle.end()).c_str(),
+		(LPCSTR)message.c_str(),
+		(LPCSTR)windowTitle.c_str(),
 		MB_ICONWARNING | MB_OKCANCEL | MB_DEFBUTTON2
 	);
 
-	bool clickedOK = false;
-	if (msgBoxRet == IDOK)
-		clickedOK = true;
-
-	return clickedOK;
+	return msgBoxRet == IDOK;
 }
 
 #elif defined(__linux) || defined(linux) || defined(__linux__) || defined(__gnu_linux__)

--- a/P4Plugin/Source/P4Task.cpp
+++ b/P4Plugin/Source/P4Task.cpp
@@ -14,7 +14,6 @@
 #include <map>
 #include <vector>
 #include <stdlib.h>
-#include <gtk/gtk.h>
 
 #if defined(_WINDOWS)
 #include "windows.h"
@@ -733,6 +732,8 @@ bool P4Task::ShowOKCancelDialogBox(const std::string& windowTitle, const std::st
 }
 
 #elif defined(__linux) || defined(linux) || defined(__linux__) || defined(__gnu_linux__)
+#include <gtk/gtk.h>
+
 static bool s_IsGtkInitialized    = false;
 static bool s_FingerprintChoiceOK = false;
 

--- a/P4Plugin/Source/P4Task.cpp
+++ b/P4Plugin/Source/P4Task.cpp
@@ -458,8 +458,14 @@ bool P4Task::IsLoggedIn()
 
 static std::string FormatFingerprintMessage(const std::string& statusMessage)
 {
-	return statusMessage.substr(0, statusMessage.find("To allow connection use the")) +
-								   "\n\nTrust this fingerprint going forward?";
+	std::string noNewlines = statusMessage;
+	for(int i = 0; i < noNewlines.size(); i++)
+	{
+		if(noNewlines[i] == '\n')
+			noNewlines[i] = ' ';
+	}
+	return noNewlines.substr(0, noNewlines.find("To allow connection use the")) +
+				    "\n\nTrust this fingerprint going forward?";
 }
 
 bool P4Task::Login()
@@ -739,7 +745,7 @@ static bool s_FingerprintChoiceOK = false;
 
 static void HandleDialogResponseAndExitLoop(GtkWidget* widget, gint response, gpointer user_data)
 {
-	s_FingerprintChoiceOK = response == GTK_RESPONSE_ACCEPT;
+	s_FingerprintChoiceOK = response == GTK_RESPONSE_OK;
 	gtk_widget_destroy(widget);
 	gtk_main_quit();
 }
@@ -751,17 +757,12 @@ bool P4Task::ShowOKCancelDialogBox(const std::string& windowTitle, const std::st
 	if(!s_IsGtkInitialized)
 		gtk_init(NULL, NULL);
 
-	GtkWidget *dialog = gtk_dialog_new_with_buttons(windowTitle.c_str(),
-							NULL,//GTK_WINDOW(window),
-							GTK_DIALOG_MODAL,
-							"_OK",
-							GTK_RESPONSE_ACCEPT,
-							"_Cancel",
-							GTK_RESPONSE_REJECT,
-							NULL);
-	GtkWidget* content_area = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
-	GtkWidget* label = gtk_label_new (message.c_str());
-	gtk_container_add (GTK_CONTAINER (content_area), label);
+	GtkWidget *dialog = gtk_message_dialog_new(NULL,
+	    GTK_DIALOG_MODAL,
+	    GTK_MESSAGE_WARNING,
+	    GTK_BUTTONS_OK_CANCEL,
+	    message.c_str());
+	gtk_window_set_title(GTK_WINDOW(dialog), windowTitle.c_str());
 
 	g_signal_connect_swapped (dialog,
 				   "response",

--- a/P4Plugin/Source/P4Task.cpp
+++ b/P4Plugin/Source/P4Task.cpp
@@ -736,6 +736,7 @@ void P4Task::EnableUTF8Mode()
 
 bool P4Task::ShowOKCancelDialogBox(const std::string& windowTitle, const std::string& message)
 {
+	SetProcessDPIAware();
 	int msgBoxRet = MessageBoxA(
 		NULL,
 		(LPCSTR)message.c_str(),

--- a/P4Plugin/Source/P4Task.h
+++ b/P4Plugin/Source/P4Task.h
@@ -63,8 +63,10 @@ private:
 	bool Dispatch(UnityCommand c, const std::vector<std::string>& args);
 
 	void EnableUTF8Mode();
+	bool ExecuteTrustThisServerFingerprintDialogBox(const std::string& statusMessage);
 
 	bool HasUnicodeNeededError(VCSStatus status);
+	bool HasServerFingerPrintError(VCSStatus status);
 	bool IsLoggedIn();
 
 

--- a/P4Plugin/Source/P4Task.h
+++ b/P4Plugin/Source/P4Task.h
@@ -63,7 +63,7 @@ private:
 	bool Dispatch(UnityCommand c, const std::vector<std::string>& args);
 
 	void EnableUTF8Mode();
-	bool ExecuteTrustThisServerFingerprintDialogBox(const std::string& statusMessage);
+	static bool ShowOKCancelDialogBox(const std::string& windowTitle, const std::string& message);
 
 	bool HasUnicodeNeededError(VCSStatus status);
 	bool HasServerFingerPrintError(VCSStatus status);

--- a/Test/Source/TestServer.cpp
+++ b/Test/Source/TestServer.cpp
@@ -438,7 +438,7 @@ static int runScript(ExternalProcess& p, const std::string& testDir, const std::
 	}
 	if (lineNum == 0)
 	{
-		std::cerr << "Invalid test script it has no lines " << testscript << std::endl;
+		//std::cerr << "Invalid test script it has no lines " << testscript << std::endl;
 		return 1;
 	}
 

--- a/Test/Source/TestServer.cpp
+++ b/Test/Source/TestServer.cpp
@@ -438,7 +438,8 @@ static int runScript(ExternalProcess& p, const std::string& testDir, const std::
 	}
 	if (lineNum == 0)
 	{
-		//std::cerr << "Invalid test script it has no lines " << testscript << std::endl;
+		//Won't compile with gcc >= 6.1
+		std::cerr << "Invalid test script it has no lines " << testscript << std::endl;
 		return 1;
 	}
 


### PR DESCRIPTION
### Purpose of this PR
To add a GUI prompt which asks the user to verify the Perforce server's SSL fingerprint. This is only done when connecting to an SSL server for the first time or when the fingerprint has changes.

This change adds a GUI dialog box with OK/cancel buttons for Windows, OSX and Linux to the PerforcePlugin. The dialog will become the topmost window when it spawns during login and it will continue to appear until the user clicks 'OK' or disables Perforce or changes the server.

If you pick 'Cancel' the plugin will forward the full unmodified Perforce error to the Unity console.

The dialog will be displayed for intervals of up to 30s as this is the IPC timeout interval for the PerforcePlugin (it should reappear after it closes)

Dialog screenshots on different platforms (not to scale):

OSX
![](https://i.imgur.com/mndr9Cz.png)

Windows
![](https://i.imgur.com/IOHMZYh.png)

Linux
![](https://i.imgur.com/kElBF1c.png)

---
### Testing status

**Manual Tests**:
- Tested on Windows 10, OSX 10.15.1 and Linux 18.04 (via VirtualBox) with an MFA SSL Perforce server. Reproduced by connecting with p4v and manually forgetting the fingerprint with the 'p4 trust -d' command through the CLI before trying to reconnect in Unity.

**Automated Tests**: 

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/421-NativeVersionControlPlugins

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
It's recommended to use the Unity branch vcs/ssl-fingerprint-dialog with this plugin update for the PerforcePlugin process not to get periodically killed by Unity when it takes longer than a few seconds to confirm the fingerprint.
