### PR TITLE
Fix all warnings in a Windows build.

### DIFF
--- a/P4Plugin/P4Plugin.vcxproj
+++ b/P4Plugin/P4Plugin.vcxproj
@@ -148,7 +148,8 @@ _SCL_SECURE_NO_DEPRECATE
       <AdditionalDependencies>libclient.lib;libeay32.lib;ssleay32.lib;librpc.lib;libsupp.lib;ws2_32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>echo f | xcopy "$(SolutionDir)$(Configuration)\$(TargetFileName)" "$(SolutionDir)Build\Win32\$(TargetFileName)" /Y</Command>
+      <Command>echo f | xcopy "$(SolutionDir)$(Configuration)\$(TargetFileName)" "$(SolutionDir)Build\Win32\$(TargetFileName)" /Y
+echo f | if exist "$(SolutionDir)$(Configuration)\$(TargetName).pdb" xcopy "$(SolutionDir)$(Configuration)\$(TargetName).pdb" "$(SolutionDir)Build\Win32\$(TargetName).pdb" /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -167,15 +168,14 @@ _SCL_SECURE_NO_DEPRECATE
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(ProjectDir)Source\r16.1\lib\win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>libclient.lib;libeay32.lib;ssleay32.lib;librpc.lib;libsupp.lib;ws2_32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>echo f | xcopy "$(SolutionDir)$(Configuration)\$(TargetFileName)" "$(SolutionDir)Build\Win32\$(TargetFileName)" /Y
-echo f | xcopy "$(SolutionDir)$(Configuration)\$(TargetName).pdb" "$(SolutionDir)Build\Win32\$(TargetName).pdb" /Y</Command>
+      <Command>echo f | xcopy "$(SolutionDir)$(Configuration)\$(TargetFileName)" "$(SolutionDir)Build\Win32\$(TargetFileName)" /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/P4Plugin/Source/P4Task.cpp
+++ b/P4Plugin/Source/P4Task.cpp
@@ -433,7 +433,7 @@ bool P4Task::IsOnline()
 static std::string FormatFingerprintMessage(const std::string& statusMessage)
 {
 	std::string noNewlines = statusMessage;
-	for (int i = 0; i < noNewlines.size(); i++)
+	for (size_t i = 0; i < noNewlines.size(); i++)
 	{
 		if (noNewlines[i] == '\n')
 			noNewlines[i] = ' ';

--- a/Test/Source/TestServer.cpp
+++ b/Test/Source/TestServer.cpp
@@ -155,7 +155,7 @@ int run(int argc, char* argv[])
 	noresults = newbaseline;
 	verbose = argc > 4 ? std::string(argv[4]) == "verbose" && !newbaseline : false;
 	char buffer[4096];
-	char *answer = getcwd(buffer, sizeof(buffer));
+	char *answer = _getcwd(buffer, sizeof(buffer));
 	if (answer)
 	{
 		absroot = buffer;
@@ -289,7 +289,7 @@ static int runScript(ExternalProcess& p, const std::string& testDir, const std::
 			{
 				std::string delfile = command.substr(delfiletoken.length(), command.length() - 1 - delfiletoken.length());
 				// Delete a local file
-				unlink(delfile.c_str());
+				_unlink(delfile.c_str());
 				continue;
 			}
 			if (command.find(sleepToken) == 0)

--- a/Test/TestServer/TestServer.vcxproj
+++ b/Test/TestServer/TestServer.vcxproj
@@ -78,7 +78,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
A few code changes fixed warnings, removed debug info for release builds, and added condition for copying .pbd which is not present in a release build.

### Purpose of this PR
Hundreds of warnings were generated during a build. Some required code changes.

---
### Testing status
Couldn't get tests to work. Installed Perforce server, but tests couldn't locate server files. Couldn't find test documentation.

---
### Comments to reviewers
@ignas2 Can you review this, and/or let me know how to run the tests?

11/02 8:30 AM PT Still waiting to hear from Fernando, who you referred me to, and who was emailed on 10/28.
11/03 4:12 AM PT Email from Fernando that it will be reviewed as soon as possible.