### PR TITLE
Covered Perforce response during the login when it warns about an exp…

### DIFF
--- a/P4Plugin/Source/P4LoginCommand.cpp
+++ b/P4Plugin/Source/P4LoginCommand.cpp
@@ -63,7 +63,7 @@ public:
 		}
 	}
 
-	bool ParseAuthenticationResponse(std::string responseText)
+	bool ParseAuthenticationResponse(const std::string& responseText)
 	{
 		if (responseText == "'login' not necessary, no password set for this user.")
 		{


### PR DESCRIPTION
### Purpose of this PR
When the Perforce license is about to expire, the server returns a warning message as part of the login response. This message is not covered by the plugin, making it think the validation failed.

Response example
```
Your license is due to expire on 2024/02/26; please contact sales@perforce.com to obtain an updated license file to avoid downtime.
User xyz logged in.
```

We improved the parsing of the login response to cover this new case. In addition, we extracted the validation of the login response to a separate method, so we can apply it to both `login` and `login -s` equally.

---
### Testing status

**Manual Tests**:
- [x] Verified that plugins work in the Editor.
- [x] Ran local tests on your machine.

**Automated Tests**:
- Perforce tests passing in Yamato for Windows, macOS and Linux.

**Yamato**:
https://unity-ci.cds.internal.unity3d.com/project/421/branch/fix%2Fuum-64620_login_failure_when_license_about_to_expire